### PR TITLE
Finish activities to prevent several back button press to close app

### DIFF
--- a/app/src/main/java/com/poupa/attestationdeplacement/CreateAttestationActivity.java
+++ b/app/src/main/java/com/poupa/attestationdeplacement/CreateAttestationActivity.java
@@ -307,8 +307,9 @@ public class CreateAttestationActivity extends AppCompatActivity {
                     ).show();
 
                     Intent show = new Intent(CreateAttestationActivity.this, MainActivity.class);
-
+                    show.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivity(show);
+                    finish();
                 }
             });
         }

--- a/app/src/main/java/com/poupa/attestationdeplacement/MainActivity.java
+++ b/app/src/main/java/com/poupa/attestationdeplacement/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                goToCreateAttestation(MainActivity.this);
+                goToCreateAttestation(MainActivity.this, false);
             }
         });
     }
@@ -78,7 +78,7 @@ public class MainActivity extends AppCompatActivity {
             List<AttestationEntity> attestations = AttestationDatabase.getInstance(weakActivity.get()).daoAccess().loadAll();
 
             if (attestations != null && attestations.size() == 0) {
-                goToCreateAttestation(weakActivity.get());
+                goToCreateAttestation(weakActivity.get(), true);
                 return null;
             }
 
@@ -101,9 +101,15 @@ public class MainActivity extends AppCompatActivity {
     /**
      * Start the create attestation activity
      */
-    private static void goToCreateAttestation(MainActivity mainActivity) {
+    private static void goToCreateAttestation(MainActivity mainActivity, boolean finish) {
         Intent intent = new Intent(mainActivity, CreateAttestationActivity.class);
+        if (finish) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        }
         mainActivity.startActivity(intent);
+        if (finish) {
+            mainActivity.finish();
+        }
     }
 
     /**


### PR DESCRIPTION
L'idée est de fermer les activité lors de l'ouverture d'une nouvelle afin d'éviter plusieurs appuis sur le bouton back pour fermer l'application, sauf dans le cas où l'on ouvre CreateAttestationActivity depuis le bouton + de MainAcitivty. 