### PR TITLE
Close CreateAttestationActivity to prevent reopening when back is pressed

### DIFF
--- a/app/src/main/java/com/poupa/attestationdeplacement/tasks/GeneratePdfTask.java
+++ b/app/src/main/java/com/poupa/attestationdeplacement/tasks/GeneratePdfTask.java
@@ -49,8 +49,10 @@ public class GeneratePdfTask extends AsyncTask<Void, Void, Void> {
                 ).show();
 
                 Intent show = new Intent(weakActivity.get(), MainActivity.class);
+                show.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
                 weakActivity.get().startActivity(show);
+                weakActivity.get().finish();
             }
         });
     }


### PR DESCRIPTION
L'idée est de pouvoir fermer l'application lorsqu'on appuie sur le bouton "back" de l'appareil. Lorsque l'on génère une nouvelle attestation, le bouton retour "réouvrait" l'activity de création d'attestation. J'ai donc "forcé" la fermeture de l'activity de création lors de la génération.